### PR TITLE
fix(deps): update to cli-table3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,18 @@
   "requires": true,
   "dependencies": {
     "@bigboat/server-client": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bigboat/server-client/-/server-client-2.0.2.tgz",
-      "integrity": "sha512-A9vptzav0IUUs4ULJ/ivDYz5GL+QodYGK8MvR0wq1kULhCk8zDRXpaTxMZPb8qjYDhOiZoMRQ68bHbgxJBP5SQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@bigboat/server-client/-/server-client-2.2.0.tgz",
+      "integrity": "sha512-gsyPhKseMVDaMY9O5EueCTcu2fR2vmGiwNfhYU3/8PNUwJj7G8CsJpHebo6RmqcoAREA/TuinqiFhULWGs4CPg==",
       "requires": {
-        "apollo-cache-inmemory": "1.1.5",
-        "apollo-client": "2.2.0",
-        "apollo-link-http": "1.3.2",
-        "apollo-link-ws": "1.0.4",
+        "apollo-cache-inmemory": "1.2.5",
+        "apollo-client": "2.3.5",
+        "apollo-link-http": "1.5.4",
+        "apollo-link-ws": "1.0.8",
         "graphql": "0.11.7",
-        "graphql-tag": "2.6.1",
+        "graphql-tag": "2.9.2",
         "node-fetch": "1.7.3",
-        "subscriptions-transport-ws": "0.9.5"
+        "subscriptions-transport-ws": "0.9.12"
       },
       "dependencies": {
         "graphql": {
@@ -30,15 +30,20 @@
       }
     },
     "@types/async": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.0.46.tgz",
-      "integrity": "sha512-G4pYI5fcrmy6/NpTUHxTV8KOJgt7xO4jU7Itx3hA+AsBiECf78vFIJdRSWM6pHIskmKfCmJ0zGVbQJuKUooEQg==",
+      "version": "2.0.49",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.0.49.tgz",
+      "integrity": "sha512-Benr3i5odUkvpFkOpzGqrltGdbSs+EVCkEBGXbuR7uT0VzhXKIkhem6PDzHdx5EonA+rfbB3QvP6aDOw5+zp5Q==",
       "optional": true
     },
+    "@types/graphql": {
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz",
+      "integrity": "sha512-wXAVyLfkG1UMkKOdMijVWFky39+OD/41KftzqfX1Oejd0Gm6dOIKjCihSVECg6X7PHjftxXmfOKA/d1H79ZfvQ=="
+    },
     "@types/zen-observable": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.5.3.tgz",
-      "integrity": "sha512-aDvGDAHcVfUqNmd8q4//cHAP+HGxsbChbBbuk3+kMVk5TTxfWLpQWvVN3+UPjohLnwMYN7jr6BWNn2cYNqdm7g=="
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.5.4.tgz",
+      "integrity": "sha512-sW6xN96wUak4tgc89d0tbTg7QDGYhGv5hvQIS6h4mRCd8h2btiZ80loPU8cyLwsBbA4ZeQt0FjvUhJ4rNhdsGg=="
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -46,9 +51,9 @@
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -56,83 +61,88 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "apollo-cache": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.0.tgz",
-      "integrity": "sha512-ILs1/GCyAv8RRMansOqpENnsJMCc1w6UQKVY6vTxJBpUDpGO6B6/UbIaWM0esat9cf92a7yx13/BoauFRzwqzw==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.12.tgz",
+      "integrity": "sha512-D0BPiHvJ6vIrXRh6P4mwlxuUOvODGuJxJq+zIjP8fADIqwjYtH3U3d/PY8dQ2fn4bDbvIAWBUkADBuJLpLIIpg==",
       "requires": {
-        "apollo-utilities": "1.0.4"
+        "apollo-utilities": "1.0.16"
       }
     },
     "apollo-cache-inmemory": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.1.5.tgz",
-      "integrity": "sha512-Gy9g4RZUfIJwxaZuMF3ZqplYaiFSfgJYmepYTIP+zL+9dqV1Er8EIICJqVlc4T2uWXHQ9U01iK5Hu1g9pV85tg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.2.5.tgz",
+      "integrity": "sha512-D9KIT4bq7ORm0BVXjSIxU09SvTUunWKxM63Lvr81hR83I7B7RRM3uFBDUV9VG8rlIGkD+1obBNlW2ycerFV8wQ==",
       "requires": {
-        "apollo-cache": "1.1.0",
-        "apollo-utilities": "1.0.4",
-        "graphql-anywhere": "4.1.1"
+        "apollo-cache": "1.1.12",
+        "apollo-utilities": "1.0.16",
+        "graphql-anywhere": "4.1.14"
       }
     },
     "apollo-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.2.0.tgz",
-      "integrity": "sha512-PSocHEbRoubHIV+GD/bHMACFstbEv9a4FLgu41d2djpwAIIiT37qgnfLbnvY7BlME0vKc7HIV6sYjLY3xnjY4Q==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.3.5.tgz",
+      "integrity": "sha512-FYg+Mj/HWSaO/ZllT5JnyHGUhkFhZ+UOdEvJd/DYKjxHNPal/d3jyXtG947r4IhUqPmmxXsAXNwvJGPieBKJGg==",
       "requires": {
-        "@types/async": "2.0.46",
-        "@types/zen-observable": "0.5.3",
-        "apollo-cache": "1.1.0",
-        "apollo-link": "1.0.7",
-        "apollo-link-dedup": "1.0.5",
-        "apollo-utilities": "1.0.4",
-        "symbol-observable": "1.1.0",
-        "zen-observable": "0.7.1"
+        "@types/async": "2.0.49",
+        "@types/zen-observable": "0.5.4",
+        "apollo-cache": "1.1.12",
+        "apollo-link": "1.2.2",
+        "apollo-link-dedup": "1.0.9",
+        "apollo-utilities": "1.0.16",
+        "symbol-observable": "1.2.0",
+        "zen-observable": "0.8.8"
       }
     },
     "apollo-link": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.0.7.tgz",
-      "integrity": "sha512-oHzvpIDEy4UCNdbOw42wtOK1zOzdMrt4ulYyon24zT24MjicezTmXqJh2mR6whTl8RiUDLDY4ByusdKKXdcqHw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.2.tgz",
+      "integrity": "sha512-Uk/BC09dm61DZRDSu52nGq0nFhq7mcBPTjy5EEH1eunJndtCaNXQhQz/BjkI2NdrfGI+B+i5he6YSoRBhYizdw==",
       "requires": {
-        "@types/zen-observable": "0.5.3",
-        "apollo-utilities": "1.0.4",
-        "zen-observable": "0.6.1"
-      },
-      "dependencies": {
-        "zen-observable": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.6.1.tgz",
-          "integrity": "sha512-DKjFTL7siVLIUMZOFZ0alqMEdTsXPUxoCZzrvB2tdWEVN/6606Qh1nCfSTCAOZMrtcPzzFI3BXmwBKLAew52NA=="
-        }
+        "@types/graphql": "0.12.6",
+        "apollo-utilities": "1.0.16",
+        "zen-observable-ts": "0.8.9"
       }
     },
     "apollo-link-dedup": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.5.tgz",
-      "integrity": "sha512-KxBC8RapBctNX7o/bxMi5LdLA5VhD9ng8Td0tG+zlib5WV5wMERBCclgd9LqRdt1CkxJ/gsrTfBh38LcVhpWvg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.9.tgz",
+      "integrity": "sha512-RbuEKpmSHVMtoREMPh2wUFTeh65q+0XPVeqgaOP/rGEAfvLyOMvX0vT2nVaejMohoMxuUnfZwpldXaDFWnlVbg==",
       "requires": {
-        "apollo-link": "1.0.7"
+        "apollo-link": "1.2.2"
       }
     },
     "apollo-link-http": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.3.2.tgz",
-      "integrity": "sha512-yFSVoSZgSbJjyZzKqcxf3GTuCCLRLJ1m1V/NHnN0xvLpuNBx24MeBf0OnY5/rHIyzH/nm4HY7hhc0eZockdyIA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.4.tgz",
+      "integrity": "sha512-e9Ng3HfnW00Mh3TI6DhNRfozmzQOtKgdi+qUAsHBOEcTP0PTAmb+9XpeyEEOueLyO0GXhB92HUCIhzrWMXgwyg==",
       "requires": {
-        "apollo-link": "1.0.7"
+        "apollo-link": "1.2.2",
+        "apollo-link-http-common": "0.2.4"
+      }
+    },
+    "apollo-link-http-common": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.4.tgz",
+      "integrity": "sha512-4j6o6WoXuSPen9xh4NBaX8/vL98X1xY2cYzUEK1F8SzvHe2oFONfxJBTekwU8hnvapcuq8Qh9Uct+gelu8T10g==",
+      "requires": {
+        "apollo-link": "1.2.2"
       }
     },
     "apollo-link-ws": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.4.tgz",
-      "integrity": "sha512-ioJGvhNu9PnIxzi00m3HOoW/gQ+AB7+Y9qtv1taPsIdNxV0FDKoMkL6N5Nf0KnWUPDysT8XcrOml5/VfF558nw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.8.tgz",
+      "integrity": "sha512-ucuGvr8CBBwCHl/Rbtyuv9Fn0FN5Qoyvy84KHtuMl2Uux2Sq+jt3bUum+pZ+hZntEd9k8M1OjrrXqRJ4PtEpyA==",
       "requires": {
-        "apollo-link": "1.0.7"
+        "apollo-link": "1.2.2"
       }
     },
     "apollo-utilities": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.4.tgz",
-      "integrity": "sha512-QnxSxRuJLCpa91P2Tzi3PCdpPydpBEawsHedr/hW7QrgOpn1fOicxgVrzhxt/au9rXSopwyDTBsGa7wEvz+DQQ=="
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.16.tgz",
+      "integrity": "sha512-5oKnElKqkV920KRbitiyISLeG63tUGAyNdotg58bQSX9Omr+smoNDTIRMRLbyIdKOYLaw3LpDaRepOPqljj0NQ==",
+      "requires": {
+        "fast-json-stable-stringify": "2.0.0"
+      }
     },
     "async-limiter": {
       "version": "1.0.0",
@@ -145,7 +155,7 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
+        "core-js": "2.5.7",
         "regenerator-runtime": "0.10.5"
       }
     },
@@ -154,7 +164,7 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
@@ -180,6 +190,21 @@
         "has-ansi": "2.0.0",
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
       }
     },
     "cli-cursor": {
@@ -190,27 +215,14 @@
         "restore-cursor": "1.0.1"
       }
     },
-    "cli-table2": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
-      "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
+    "cli-table3": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.0.tgz",
+      "integrity": "sha512-c7YHpUyO1SaKaO7kYtxd5NZ8FjAmSK3LpKkuzdwn+2CwpFxBpdoQLm+OAnnCfoEl7onKhN9PKQi1lsHuAIUqGQ==",
       "requires": {
-        "colors": "1.1.2",
-        "lodash": "3.10.1",
-        "string-width": "1.0.2"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-          "optional": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
+        "colors": "1.3.0",
+        "object-assign": "4.1.1",
+        "string-width": "2.1.1"
       }
     },
     "cli-width": {
@@ -224,21 +236,21 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+      "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
     },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "0.4.23"
       }
     },
     "escape-string-regexp": {
@@ -247,14 +259,19 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
     },
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "figures": {
       "version": "1.7.0",
@@ -274,17 +291,17 @@
       }
     },
     "graphql-anywhere": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.1.1.tgz",
-      "integrity": "sha512-CMbuqNbp6nfHfOHswrDuEed+MxDSnLppHKjjte447P6fllqZi69D2bS/3QSfK/KONSgvpk3ptxNi4fR6WQFcSQ==",
+      "version": "4.1.14",
+      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.1.14.tgz",
+      "integrity": "sha512-Wy4h9FWwxgrDRP16wXApP/VmNKXXTvY8jZLDtgxwDuC8Z6LSVkeCDjQSCyNKdgktky104UCbIQ3x+et9bQupDA==",
       "requires": {
-        "apollo-utilities": "1.0.4"
+        "apollo-utilities": "1.0.16"
       }
     },
     "graphql-tag": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.6.1.tgz",
-      "integrity": "sha1-R4jVCfbilgfZR/xHpAxOGPc200o="
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.9.2.tgz",
+      "integrity": "sha512-qnNmof9pAqj/LUzs3lStP0Gw1qhdVCUS7Ab7+SUB6KD5aX1uqxWQRwMnOGTkhKuLvLNIs1TvNz+iS9kUGl1MhA=="
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -292,12 +309,22 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
         "ansi-regex": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        }
       }
     },
     "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
     },
     "in-publish": {
       "version": "2.0.0",
@@ -323,20 +350,30 @@
         "through": "2.3.8"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         }
       }
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -349,24 +386,9 @@
       "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
-    "lodash.isobject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "log-update": {
       "version": "1.0.2",
@@ -421,7 +443,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "readline2": {
@@ -432,6 +454,16 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "mute-stream": "0.0.5"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        }
       }
     },
     "regenerator-runtime": {
@@ -461,42 +493,45 @@
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
     },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "3.0.0"
       }
     },
     "subscriptions-transport-ws": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.5.tgz",
-      "integrity": "sha512-YFTdjCzSlDcY0UiagrA7dOt+OuvG/xQAvP1kuKVT5VgU0IQjGJste01MfIpwoH9DrD78Kbh/q0usOj4hoaITow==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.12.tgz",
+      "integrity": "sha512-57Ar8hjr/63fCx1kM3kyDr64FAPQITMguuFuTGgYVx2v1JOaPoTeZyTIenVPgv+7mDYt7E+h+Jyxvznb+UKVWw==",
       "requires": {
         "backo2": "1.0.2",
-        "eventemitter3": "2.0.3",
-        "iterall": "1.1.3",
-        "lodash.assign": "4.2.0",
-        "lodash.isobject": "3.0.2",
-        "lodash.isstring": "4.0.1",
-        "symbol-observable": "1.1.0",
-        "ws": "3.3.3"
+        "eventemitter3": "3.1.0",
+        "iterall": "1.2.2",
+        "symbol-observable": "1.2.0",
+        "ws": "5.2.1"
+      },
+      "dependencies": {
+        "iterall": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+          "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+        }
       }
     },
     "supports-color": {
@@ -505,19 +540,14 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "symbol-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
-      "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "vorpal": {
       "version": "1.12.0",
@@ -528,12 +558,27 @@
         "chalk": "1.1.3",
         "in-publish": "2.0.0",
         "inquirer": "0.11.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "log-update": "1.0.2",
         "minimist": "1.2.0",
         "node-localstorage": "0.6.0",
         "strip-ansi": "3.0.1",
         "wrap-ansi": "2.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
       }
     },
     "wrap-ansi": {
@@ -543,6 +588,39 @@
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
       }
     },
     "wrappy": {
@@ -551,19 +629,25 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.1.tgz",
+      "integrity": "sha512-2NkHdPKjDBj3CHdnAGNpmlliryKqF+n9MYXX7/wsVC4yqYocKreKNjydPDvT3wShAZnndlM0RytEfTALCDvz7A==",
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "async-limiter": "1.0.0"
       }
     },
     "zen-observable": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
-      "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg=="
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.8.tgz",
+      "integrity": "sha512-HnhhyNnwTFzS48nihkCZIJGsWGFcYUz+XPDlPK5W84Ifji8SksC6m7sQWOf8zdCGhzQ4tDYuMYGu5B0N1dXTtg=="
+    },
+    "zen-observable-ts": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.9.tgz",
+      "integrity": "sha512-KJz2O8FxbAdAU5CSc8qZ1K2WYEJb1HxS6XDRF+hOJ1rOYcg6eTMmS9xYHCXzqZZzKw6BbXWyF4UpwSsBQnHJeA==",
+      "requires": {
+        "zen-observable": "0.8.8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "apollo-cache-inmemory": "^1.1.5",
     "apollo-client": "^2.2.0",
     "apollo-link-http": "^1.3.2",
-    "cli-table2": "^0.2.0",
+    "cli-table3": "^0.5.0",
     "colors": "^1.1.2",
     "graphql": "^0.12.3",
     "graphql-tag": "^2.6.1",

--- a/src/commands/app.js
+++ b/src/commands/app.js
@@ -1,5 +1,5 @@
 const fs = require("fs");
-const Table = require("cli-table2");
+const Table = require("cli-table3");
 
 module.exports = ({ client, tableStyle }) => (vorpal, options) => {
   vorpal

--- a/src/commands/bucket.js
+++ b/src/commands/bucket.js
@@ -1,4 +1,4 @@
-const Table = require("cli-table2");
+const Table = require("cli-table3");
 
 module.exports = ({ client, tableStyle }) => (vorpal, options) => {
   vorpal

--- a/src/commands/instance.js
+++ b/src/commands/instance.js
@@ -1,4 +1,4 @@
-const Table = require('cli-table2')
+const Table = require('cli-table3')
 const colors = require('colors')
 
 const v = (val) => val ? val : ''


### PR DESCRIPTION
This PR updates the cli-table2 dependency to cli-table3, which fixes one of the npm audit warnings :)

cli-table2 (like cli-table itself) is no longer maintained. In jamestalmage/cli-table2#43 a couple of people have offered to take over maintenance but the current maintainer did not respond so as a result the project was forked to cli-table/cli-table3.